### PR TITLE
Move to atomic_polyfill from radium

### DIFF
--- a/bitvec/Cargo.toml
+++ b/bitvec/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "bitvec"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 
 categories = [
@@ -40,9 +40,11 @@ rust-version = "1.60"
 
 [features]
 alloc = []
-atomic = ["atomic-polyfill"]
+atomic = []
 # Enable use of atomics and the standard library by default. no-std
 # users will need to opt out with `default-features = false`.
+# As of version 2.0, atomic is an ignored feature since polyfills
+# are used
 default = ["atomic", "std"]
 # The standard library includes the allocator.
 std = ["alloc"]
@@ -53,7 +55,6 @@ tap = "1"
 
 [dependencies.atomic-polyfill]
 version = "1.0"
-optional = true
 
 [dependencies.funty]
 version = "^2.0"

--- a/bitvec/Cargo.toml
+++ b/bitvec/Cargo.toml
@@ -36,29 +36,24 @@ keywords = [
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ferrilab/ferrilab"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [features]
-alloc = [
-]
-atomic = [
-]
+alloc = []
+atomic = ["atomic-polyfill"]
 # Enable use of atomics and the standard library by default. no-std
 # users will need to opt out with `default-features = false`.
-default = [
-	"atomic",
-	"std",
-]
+default = ["atomic", "std"]
 # The standard library includes the allocator.
-std = [
-	"alloc",
-]
-testing = [
-]
+std = ["alloc"]
+testing = []
 
 [dependencies]
-radium = "0.7"
 tap = "1"
+
+[dependencies.atomic-polyfill]
+version = "1.0"
+optional = true
 
 [dependencies.funty]
 version = "^2.0"

--- a/bitvec/doc/macros/bitarr_value.md
+++ b/bitvec/doc/macros/bitarr_value.md
@@ -6,7 +6,7 @@ superset of the [`vec!`] arguments, and is capable of producing bit-arrays in
 
 Like `vec!`, it can accept a sequence of comma-separated bit values, or a
 semicolon-separated pair of a bit value and a repetition counter. Bit values may
-be any integer or name of a `const` integer, but *should* only be `0` or `1`.
+be any integer or name of a `const` integer, but _should_ only be `0` or `1`.
 
 ## Argument Syntax
 
@@ -25,6 +25,7 @@ It accepts zero, one, or three prefix arguments:
   at the macro invocation site.
 
   When not provided, this defaults to `Lsb0`.
+
 - `$store ;`: This must be one of `uTYPE`, `Cell<uTYPE>`, `AtomicUTYPE`, or
   `RadiumUTYPE` where `TYPE` is one of `8`, `16`, `32`, `64`, or `size`. The
   macro recognizes this token textually, and does not have access to the type
@@ -44,7 +45,7 @@ together.
 ```rust
 use bitvec::prelude::*;
 use core::{cell::Cell, mem};
-use radium::types::*;
+use atomic_polyfill::*;
 
 let a: BitArray = bitarr![0, 1, 0, 0, 1];
 
@@ -54,7 +55,7 @@ assert_eq!(b.len(), mem::size_of::<usize>() * 8);
 let c = bitarr![u16, Lsb0; 0, 1, 0, 0, 1];
 let d = bitarr![Cell<u16>, Msb0; 1; 10];
 const E: BitArray<[u32; 1], LocalBits> = bitarr![u32, LocalBits; 1; 15];
-let f = bitarr![RadiumU32, Msb0; 1; 20];
+let f = bitarr![AtomicU32, Msb0; 1; 20];
 ```
 
 [`BitArray`]: crate::array::BitArray

--- a/bitvec/doc/macros/bits.md
+++ b/bitvec/doc/macros/bits.md
@@ -6,7 +6,7 @@ bit-slices in `const` contexts (for known type parameters).
 
 Like `vec!`, it can accept a sequence of comma-separated bit values, or a
 semicolon-separated pair of a bit value and a repetition counter. Bit values may
-be any integer or name of a `const` integer, but *should* only be `0` or `1`.
+be any integer or name of a `const` integer, but _should_ only be `0` or `1`.
 
 ## Argument Syntax
 
@@ -37,6 +37,7 @@ The next possible arguments are a pair of `BitOrder`/`BitStore` type parameters.
   at the macro invocation site.
 
   When not provided, this defaults to `Lsb0`.
+
 - `$store ;`: This must be one of `uTYPE`, `Cell<uTYPE>`, `AtomicUTYPE`, or
   `RadiumUTYPE` where `TYPE` is one of `8`, `16`, `32`, `64`, or `size`. The
   macro recognizes this token textually, and does not have access to the type
@@ -54,7 +55,7 @@ together.
 ## Safety
 
 Rust considers all `static mut` bindings to be `unsafe` to use. While `bits!`
-can prevent *some* of this unsafety by preventing direct access to the created
+can prevent _some_ of this unsafety by preventing direct access to the created
 `static mut` buffer, there are still ways to create multiple names referring to
 the same underlying buffer.
 
@@ -85,7 +86,7 @@ existing alias-protection behavior suffices.
 ```rust
 use bitvec::prelude::*;
 use core::cell::Cell;
-use radium::types::*;
+use atomic_polyfill::*;
 
 let a: &BitSlice = bits![0, 1, 0, 0, 1];
 
@@ -95,7 +96,7 @@ assert_eq!(b.len(), 5);
 let c = bits![u16, Lsb0; 0, 1, 0, 0, 1];
 let d = bits![static Cell<u16>, Msb0; 1; 10];
 let e = unsafe { bits![static mut u32, LocalBits; 0; 15] };
-let f = bits![RadiumU32, Msb0; 1; 20];
+let f = bits![AtomicU32, Msb0; 1; 20];
 ```
 
 [`BitSlice`]: crate::slice::BitSlice

--- a/bitvec/rust-toolchain.toml
+++ b/bitvec/rust-toolchain.toml
@@ -6,13 +6,9 @@
 ########################################################################
 
 [toolchain]
-channel = "1.56.0"
+channel = "1.60.0"
 profile = "default"
-components = [
-	"clippy",
-	"rustfmt",
-	"rust-src",
-]
+components = ["clippy", "rustfmt", "rust-src"]
 # channel = "nightly"
 # components = [
 # 	"miri",

--- a/bitvec/src/access.rs
+++ b/bitvec/src/access.rs
@@ -1,9 +1,12 @@
 #![doc = include_str!("../doc/access.md")]
 
-use core::sync::atomic::Ordering;
+use core::{
+	cell::Cell,
+	sync::atomic::Ordering,
+};
 
+use atomic_polyfill::*;
 use funty::Integral;
-use radium::Radium;
 
 use crate::{
 	index::{
@@ -14,9 +17,81 @@ use crate::{
 	order::BitOrder,
 };
 
+/// This trait is used to define the needed Atomic operations for bit access to
+/// an atomic.
+pub trait InternalAtomic: Sized {
+	/// The underlying item type for an atomic or cell
+	type Item;
+	/// Atomic fetch_and
+	fn fetch_and(&self, val: Self::Item, order: Ordering) -> Self::Item;
+	/// Atomic fetch_or
+	fn fetch_or(&self, val: Self::Item, order: Ordering) -> Self::Item;
+	/// Atomic fetch_xor
+	fn fetch_xor(&self, val: Self::Item, order: Ordering) -> Self::Item;
+}
+
+/// Implement Radium trait for atomics
+macro_rules! impl_radium_atomic {
+	($real:ty, $base:ty) => {
+		impl InternalAtomic for $real {
+			type Item = $base;
+
+			fn fetch_and(&self, val: Self::Item, order: Ordering) -> Self::Item {
+				self.fetch_and(val, order)
+			}
+
+			fn fetch_or(&self, val: Self::Item, order: Ordering) -> Self::Item {
+				self.fetch_or(val, order)
+			}
+
+			fn fetch_xor(&self, val: Self::Item, order: Ordering) -> Self::Item {
+				self.fetch_xor(val, order)
+			}
+		}
+	};
+}
+impl_radium_atomic!(AtomicU8, u8);
+impl_radium_atomic!(AtomicU16, u16);
+impl_radium_atomic!(AtomicU32, u32);
+impl_radium_atomic!(AtomicU64, u64);
+impl_radium_atomic!(AtomicUsize, usize);
+
+/// Implement Radium trait for Cell types
+macro_rules! impl_radium_cell {
+	($real:ty, $base:ty) => {
+		impl InternalAtomic for $real {
+			type Item = $base;
+
+			fn fetch_and(
+				&self,
+				val: Self::Item,
+				_order: Ordering,
+			) -> Self::Item {
+				self.replace(self.get() & val)
+			}
+
+			fn fetch_or(&self, val: Self::Item, _order: Ordering) -> Self::Item {
+				self.replace(self.get() | val)
+			}
+
+			fn fetch_xor(
+				&self,
+				val: Self::Item,
+				_order: Ordering,
+			) -> Self::Item {
+				self.replace(self.get() ^ val)
+			}
+		}
+	};
+}
+impl_radium_cell!(Cell<u8>, u8);
+impl_radium_cell!(Cell<u16>, u16);
+impl_radium_cell!(Cell<u32>, u32);
+impl_radium_cell!(Cell<u64>, u64);
+impl_radium_cell!(Cell<usize>, usize);
 #[doc = include_str!("../doc/access/BitAccess.md")]
-pub trait BitAccess: Radium
-where <Self as Radium>::Item: BitRegister
+pub trait BitAccess: InternalAtomic
+where <Self as InternalAtomic>::Item: BitRegister
 {
 	/// Clears bits within a memory element to `0`.
 	///
@@ -167,7 +242,7 @@ where <Self as Radium>::Item: BitRegister
 
 impl<A> BitAccess for A
 where
-	A: Radium,
+	A: InternalAtomic,
 	A::Item: BitRegister,
 {
 }
@@ -184,7 +259,7 @@ pub trait BitSafe {
 	///
 	/// This is exposed as an associated type so that `BitStore` can name it
 	/// without having to re-select it based on crate configuration.
-	type Rad: Radium<Item = Self::Mem>;
+	type Rad: InternalAtomic<Item = Self::Mem>;
 
 	/// The zero constant.
 	const ZERO: Self;
@@ -236,15 +311,15 @@ macro_rules! safe {
 }
 
 safe! {
-	u8 => BitSafeU8 => radium::types::RadiumU8;
-	u16 => BitSafeU16 => radium::types::RadiumU16;
-	u32 => BitSafeU32 => radium::types::RadiumU32;
+	u8 => BitSafeU8 => AtomicU8;
+	u16 => BitSafeU16 => AtomicU16;
+	u32 => BitSafeU32 => AtomicU32;
 }
 
 #[cfg(target_pointer_width = "64")]
-safe!(u64 => BitSafeU64 => radium::types::RadiumU64);
+safe!(u64 => BitSafeU64 => AtomicU64);
 
-safe!(usize => BitSafeUsize => radium::types::RadiumUsize);
+safe!(usize => BitSafeUsize => AtomicUsize);
 
 #[cfg(test)]
 mod tests {

--- a/bitvec/src/access.rs
+++ b/bitvec/src/access.rs
@@ -294,11 +294,7 @@ macro_rules! safe {
 		impl BitSafe for $w {
 			type Mem = $t;
 
-			#[cfg(feature = "atomic")]
 			type Rad = $r;
-
-			#[cfg(not(feature = "atomic"))]
-			type Rad = core::cell::Cell<$t>;
 
 			const ZERO: Self = Self::new(0);
 

--- a/bitvec/src/domain.rs
+++ b/bitvec/src/domain.rs
@@ -43,7 +43,10 @@ use wyz::{
 };
 
 use crate::{
-	access::BitAccess,
+	access::{
+		BitAccess,
+		InternalAtomic,
+	},
 	index::{
 		BitEnd,
 		BitIdx,
@@ -877,7 +880,7 @@ impl<'a, M, T, O> PartialElement<'a, M, T, O>
 where
 	M: Mutability,
 	O: BitOrder,
-	T: 'a + BitStore + radium::Radium,
+	T: 'a + BitStore + InternalAtomic,
 {
 	/// Performs a store operation on a partial-element whose bits might be
 	/// observed by another handle.

--- a/bitvec/src/macros/internal.rs
+++ b/bitvec/src/macros/internal.rs
@@ -28,9 +28,6 @@ macro_rules! __encode_bits {
 	(AtomicU8, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(AtomicU8 as u8, $ord; $($val),*)
 	};
-	(RadiumU8, $ord:tt; $($val:expr),*) => {
-		$crate::__encode_bits!(RadiumU8 as u8, $ord; $($val),*)
-	};
 
 	(u16, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(u16 as u16, $ord; $($val),*)
@@ -40,9 +37,6 @@ macro_rules! __encode_bits {
 	};
 	(AtomicU16, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(AtomicU16 as u16, $ord; $($val),*)
-	};
-	(RadiumU16, $ord:tt; $($val:expr),*) => {
-		$crate::__encode_bits!(RadiumU16 as u16, $ord; $($val),*)
 	};
 
 	(u32, $ord:tt; $($val:expr),*) => {
@@ -54,9 +48,6 @@ macro_rules! __encode_bits {
 	(AtomicU32, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(AtomicU32 as u32, $ord; $($val),*)
 	};
-	(RadiumU32, $ord:tt; $($val:expr),*) => {
-		$crate::__encode_bits!(RadiumU32 as u32, $ord; $($val),*)
-	};
 
 	(u64, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(u64 as u64, $ord; $($val),*)
@@ -67,9 +58,6 @@ macro_rules! __encode_bits {
 	(AtomicU64, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(AtomicU64 as u64, $ord; $($val),*)
 	};
-	(RadiumU64, $ord:tt; $($val:expr),*) => {
-		$crate::__encode_bits!(RadiumU64 as u64, $ord; $($val),*)
-	};
 
 	(usize, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(usize as usize, $ord; $($val),*)
@@ -79,9 +67,6 @@ macro_rules! __encode_bits {
 	};
 	(AtomicUsize, $ord:tt; $($val:expr),*) => {
 		$crate::__encode_bits!(AtomicUsize as usize, $ord; $($val),*)
-	};
-	(RadiumUsize, $ord:tt; $($val:expr),*) => {
-		$crate::__encode_bits!(RadiumUsize as usize, $ord; $($val),*)
 	};
 
 	//  This arm routes `usize` into `u32` or `u64`, depending on target, and

--- a/bitvec/src/macros/tests.rs
+++ b/bitvec/src/macros/tests.rs
@@ -2,12 +2,9 @@
 
 #![cfg(test)]
 
-use core::{
-	cell::Cell,
-	sync::atomic::*,
-};
+use core::cell::Cell;
 
-use radium::types::*;
+use atomic_polyfill::*;
 
 use crate::{
 	mem::bits_of,
@@ -231,50 +228,29 @@ fn compile_bits() {
 		let _: &BitSlice<u64, Msb0> = bits![u64, crate::order::Msb0; 1; 100];
 	}
 
-	radium::if_atomic! {
-		if atomic(8) {
-			let _: &BitSlice<AtomicU8, LocalBits> = bits![AtomicU8, LocalBits; 0, 1];
-			let _: &BitSlice<AtomicU8, Lsb0> = bits![AtomicU8, Lsb0; 0, 1];
-			let _: &BitSlice<AtomicU8, Msb0> = bits![AtomicU8, Msb0; 0, 1];
-			let _: &BitSlice<RadiumU8, LocalBits> = bits![RadiumU8, LocalBits; 1; 100];
-			let _: &BitSlice<RadiumU8, Lsb0> = bits![RadiumU8, Lsb0; 1; 100];
-			let _: &BitSlice<RadiumU8, Msb0> = bits![RadiumU8, Msb0; 1; 100];
-		}
-		if atomic(16) {
-			let _: &BitSlice<AtomicU16, LocalBits> = bits![AtomicU16, LocalBits; 0, 1];
-			let _: &BitSlice<AtomicU16, Lsb0> = bits![AtomicU16, Lsb0; 0, 1];
-			let _: &BitSlice<AtomicU16, Msb0> = bits![AtomicU16, Msb0; 0, 1];
-			let _: &BitSlice<RadiumU16, LocalBits> = bits![RadiumU16, LocalBits; 1; 100];
-			let _: &BitSlice<RadiumU16, Lsb0> = bits![RadiumU16, Lsb0; 1; 100];
-			let _: &BitSlice<RadiumU16, Msb0> = bits![RadiumU16, Msb0; 1; 100];
-		}
-		if atomic(32) {
-			let _: &BitSlice<AtomicU32, LocalBits> = bits![AtomicU32, LocalBits; 0, 1];
-			let _: &BitSlice<AtomicU32, Lsb0> = bits![AtomicU32, Lsb0; 0, 1];
-			let _: &BitSlice<AtomicU32, Msb0> = bits![AtomicU32, Msb0; 0, 1];
-			let _: &BitSlice<RadiumU32, LocalBits> = bits![RadiumU32, LocalBits; 1; 100];
-			let _: &BitSlice<RadiumU32, Lsb0> = bits![RadiumU32, Lsb0; 1; 100];
-			let _: &BitSlice<RadiumU32, Msb0> = bits![RadiumU32, Msb0; 1; 100];
-		}
-		if atomic(size) {
-			let _: &BitSlice<AtomicUsize, LocalBits> = bits![AtomicUsize, LocalBits; 0, 1];
-			let _: &BitSlice<AtomicUsize, Lsb0> = bits![AtomicUsize, Lsb0; 0, 1];
-			let _: &BitSlice<AtomicUsize, Msb0> = bits![AtomicUsize, Msb0; 0, 1];
-			let _: &BitSlice<RadiumUsize, LocalBits> = bits![RadiumUsize, LocalBits; 1; 100];
-			let _: &BitSlice<RadiumUsize, Lsb0> = bits![RadiumUsize, Lsb0; 1; 100];
-			let _: &BitSlice<RadiumUsize, Msb0> = bits![RadiumUsize, Msb0; 1; 100];
-		}
-	}
+	let _: &BitSlice<AtomicU8, LocalBits> = bits![AtomicU8, LocalBits; 0, 1];
+	let _: &BitSlice<AtomicU8, Lsb0> = bits![AtomicU8, Lsb0; 0, 1];
+	let _: &BitSlice<AtomicU8, Msb0> = bits![AtomicU8, Msb0; 0, 1];
+
+	let _: &BitSlice<AtomicU16, LocalBits> = bits![AtomicU16, LocalBits; 0, 1];
+	let _: &BitSlice<AtomicU16, Lsb0> = bits![AtomicU16, Lsb0; 0, 1];
+	let _: &BitSlice<AtomicU16, Msb0> = bits![AtomicU16, Msb0; 0, 1];
+
+	let _: &BitSlice<AtomicU32, LocalBits> = bits![AtomicU32, LocalBits; 0, 1];
+	let _: &BitSlice<AtomicU32, Lsb0> = bits![AtomicU32, Lsb0; 0, 1];
+	let _: &BitSlice<AtomicU32, Msb0> = bits![AtomicU32, Msb0; 0, 1];
+
+	let _: &BitSlice<AtomicUsize, LocalBits> =
+		bits![AtomicUsize, LocalBits; 0, 1];
+	let _: &BitSlice<AtomicUsize, Lsb0> = bits![AtomicUsize, Lsb0; 0, 1];
+	let _: &BitSlice<AtomicUsize, Msb0> = bits![AtomicUsize, Msb0; 0, 1];
+
 	#[cfg(target_pointer_width = "64")]
-	radium::if_atomic! {
-		if atomic(64) {
-			let _: &BitSlice<AtomicU64, LocalBits> = bits![AtomicU64, LocalBits; 0, 1];
-			let _: &BitSlice<AtomicU64, Lsb0> = bits![AtomicU64, Lsb0; 0, 1];
-			let _: &BitSlice<AtomicU64, Msb0> = bits![AtomicU64, Msb0; 0, 1];
-			let _: &BitSlice<RadiumU64, LocalBits> = bits![RadiumU64, LocalBits; 1; 100];
-			let _: &BitSlice<RadiumU64, Lsb0> = bits![RadiumU64, Lsb0; 1; 100];
-			let _: &BitSlice<RadiumU64, Msb0> = bits![RadiumU64, Msb0; 1; 100];
-		}
+	{
+		let _: &BitSlice<AtomicU64, LocalBits> =
+			bits![AtomicU64, LocalBits; 0, 1];
+		let _: &BitSlice<AtomicU64, Lsb0> = bits![AtomicU64, Lsb0; 0, 1];
+		let _: &BitSlice<AtomicU64, Msb0> = bits![AtomicU64, Msb0; 0, 1];
 	}
 }
 
@@ -346,50 +322,29 @@ fn compile_bitvec() {
 			bitvec![Cell<u64>, crate::order::Msb0; 1; 100];
 		let _: BitVec<u64, Msb0> = bitvec![u64, crate::order::Msb0; 1; 100];
 	}
-	radium::if_atomic! {
-		if atomic(8) {
-			let _: BitVec<AtomicU8, LocalBits> =bitvec![AtomicU8, LocalBits; 0, 1];
-			let _: BitVec<AtomicU8, Lsb0> =bitvec![AtomicU8, Lsb0; 0, 1];
-			let _: BitVec<AtomicU8, Msb0> =bitvec![AtomicU8, Msb0; 0, 1];
-			let _: BitVec<RadiumU8, LocalBits> =bitvec![RadiumU8, LocalBits; 1; 100];
-			let _: BitVec<RadiumU8, Lsb0> =bitvec![RadiumU8, Lsb0; 1; 100];
-			let _: BitVec<RadiumU8, Msb0> =bitvec![RadiumU8, Msb0; 1; 100];
-		}
-		if atomic(16) {
-			let _: BitVec<AtomicU16, LocalBits> =bitvec![AtomicU16, LocalBits; 0, 1];
-			let _: BitVec<AtomicU16, Lsb0> =bitvec![AtomicU16, Lsb0; 0, 1];
-			let _: BitVec<AtomicU16, Msb0> =bitvec![AtomicU16, Msb0; 0, 1];
-			let _: BitVec<RadiumU16, LocalBits> =bitvec![RadiumU16, LocalBits; 1; 100];
-			let _: BitVec<RadiumU16, Lsb0> =bitvec![RadiumU16, Lsb0; 1; 100];
-			let _: BitVec<RadiumU16, Msb0> =bitvec![RadiumU16, Msb0; 1; 100];
-		}
-		if atomic(32) {
-			let _: BitVec<AtomicU32, LocalBits> =bitvec![AtomicU32, LocalBits; 0, 1];
-			let _: BitVec<AtomicU32, Lsb0> =bitvec![AtomicU32, Lsb0; 0, 1];
-			let _: BitVec<AtomicU32, Msb0> =bitvec![AtomicU32, Msb0; 0, 1];
-			let _: BitVec<RadiumU32, LocalBits> =bitvec![RadiumU32, LocalBits; 1; 100];
-			let _: BitVec<RadiumU32, Lsb0> =bitvec![RadiumU32, Lsb0; 1; 100];
-			let _: BitVec<RadiumU32, Msb0> =bitvec![RadiumU32, Msb0; 1; 100];
-		}
-		if atomic(size) {
-			let _: BitVec<AtomicUsize, LocalBits> =bitvec![AtomicUsize, LocalBits; 0, 1];
-			let _: BitVec<AtomicUsize, Lsb0> =bitvec![AtomicUsize, Lsb0; 0, 1];
-			let _: BitVec<AtomicUsize, Msb0> =bitvec![AtomicUsize, Msb0; 0, 1];
-			let _: BitVec<RadiumUsize, LocalBits> =bitvec![RadiumUsize, LocalBits; 1; 100];
-			let _: BitVec<RadiumUsize, Lsb0> =bitvec![RadiumUsize, Lsb0; 1; 100];
-			let _: BitVec<RadiumUsize, Msb0> =bitvec![RadiumUsize, Msb0; 1; 100];
-		}
-	}
+	let _: BitVec<AtomicU8, LocalBits> = bitvec![AtomicU8, LocalBits; 0, 1];
+	let _: BitVec<AtomicU8, Lsb0> = bitvec![AtomicU8, Lsb0; 0, 1];
+	let _: BitVec<AtomicU8, Msb0> = bitvec![AtomicU8, Msb0; 0, 1];
+
+	let _: BitVec<AtomicU16, LocalBits> = bitvec![AtomicU16, LocalBits; 0, 1];
+	let _: BitVec<AtomicU16, Lsb0> = bitvec![AtomicU16, Lsb0; 0, 1];
+	let _: BitVec<AtomicU16, Msb0> = bitvec![AtomicU16, Msb0; 0, 1];
+
+	let _: BitVec<AtomicU32, LocalBits> = bitvec![AtomicU32, LocalBits; 0, 1];
+	let _: BitVec<AtomicU32, Lsb0> = bitvec![AtomicU32, Lsb0; 0, 1];
+	let _: BitVec<AtomicU32, Msb0> = bitvec![AtomicU32, Msb0; 0, 1];
+
+	let _: BitVec<AtomicUsize, LocalBits> =
+		bitvec![AtomicUsize, LocalBits; 0, 1];
+	let _: BitVec<AtomicUsize, Lsb0> = bitvec![AtomicUsize, Lsb0; 0, 1];
+	let _: BitVec<AtomicUsize, Msb0> = bitvec![AtomicUsize, Msb0; 0, 1];
+
 	#[cfg(target_pointer_width = "64")]
-	radium::if_atomic! {
-		if atomic(64) {
-			let _: BitVec<AtomicU64, LocalBits> =bitvec![AtomicU64, LocalBits; 0, 1];
-			let _: BitVec<AtomicU64, Lsb0> =bitvec![AtomicU64, Lsb0; 0, 1];
-			let _: BitVec<AtomicU64, Msb0> =bitvec![AtomicU64, Msb0; 0, 1];
-			let _: BitVec<RadiumU64, LocalBits> =bitvec![RadiumU64, LocalBits; 1; 100];
-			let _: BitVec<RadiumU64, Lsb0> =bitvec![RadiumU64, Lsb0; 1; 100];
-			let _: BitVec<RadiumU64, Msb0> =bitvec![RadiumU64, Msb0; 1; 100];
-		}
+	{
+		let _: BitVec<AtomicU64, LocalBits> =
+			bitvec![AtomicU64, LocalBits; 0, 1];
+		let _: BitVec<AtomicU64, Lsb0> = bitvec![AtomicU64, Lsb0; 0, 1];
+		let _: BitVec<AtomicU64, Msb0> = bitvec![AtomicU64, Msb0; 0, 1];
 	}
 }
 
@@ -461,50 +416,29 @@ fn compile_bitbox() {
 			bitbox![Cell<u64>, crate::order::Msb0; 1; 100];
 		let _: BitBox<u64, Msb0> = bitbox![u64, crate::order::Msb0; 1; 100];
 	}
-	radium::if_atomic! {
-		if atomic(8) {
-			let _: BitBox<AtomicU8, LocalBits> =bitbox![AtomicU8, LocalBits; 0, 1];
-			let _: BitBox<AtomicU8, Lsb0> =bitbox![AtomicU8, Lsb0; 0, 1];
-			let _: BitBox<AtomicU8, Msb0> =bitbox![AtomicU8, Msb0; 0, 1];
-			let _: BitBox<RadiumU8, LocalBits> =bitbox![RadiumU8, LocalBits; 1; 100];
-			let _: BitBox<RadiumU8, Lsb0> =bitbox![RadiumU8, Lsb0; 1; 100];
-			let _: BitBox<RadiumU8, Msb0> =bitbox![RadiumU8, Msb0; 1; 100];
-		}
-		if atomic(16) {
-			let _: BitBox<AtomicU16, LocalBits> =bitbox![AtomicU16, LocalBits; 0, 1];
-			let _: BitBox<AtomicU16, Lsb0> =bitbox![AtomicU16, Lsb0; 0, 1];
-			let _: BitBox<AtomicU16, Msb0> =bitbox![AtomicU16, Msb0; 0, 1];
-			let _: BitBox<RadiumU16, LocalBits> =bitbox![RadiumU16, LocalBits; 1; 100];
-			let _: BitBox<RadiumU16, Lsb0> =bitbox![RadiumU16, Lsb0; 1; 100];
-			let _: BitBox<RadiumU16, Msb0> =bitbox![RadiumU16, Msb0; 1; 100];
-		}
-		if atomic(32) {
-			let _: BitBox<AtomicU32, LocalBits> =bitbox![AtomicU32, LocalBits; 0, 1];
-			let _: BitBox<AtomicU32, Lsb0> =bitbox![AtomicU32, Lsb0; 0, 1];
-			let _: BitBox<AtomicU32, Msb0> =bitbox![AtomicU32, Msb0; 0, 1];
-			let _: BitBox<RadiumU32, LocalBits> =bitbox![RadiumU32, LocalBits; 1; 100];
-			let _: BitBox<RadiumU32, Lsb0> =bitbox![RadiumU32, Lsb0; 1; 100];
-			let _: BitBox<RadiumU32, Msb0> =bitbox![RadiumU32, Msb0; 1; 100];
-		}
-		if atomic(size) {
-			let _: BitBox<AtomicUsize, LocalBits> =bitbox![AtomicUsize, LocalBits; 0, 1];
-			let _: BitBox<AtomicUsize, Lsb0> =bitbox![AtomicUsize, Lsb0; 0, 1];
-			let _: BitBox<AtomicUsize, Msb0> =bitbox![AtomicUsize, Msb0; 0, 1];
-			let _: BitBox<RadiumUsize, LocalBits> =bitbox![RadiumUsize, LocalBits; 1; 100];
-			let _: BitBox<RadiumUsize, Lsb0> =bitbox![RadiumUsize, Lsb0; 1; 100];
-			let _: BitBox<RadiumUsize, Msb0> =bitbox![RadiumUsize, Msb0; 1; 100];
-		}
-	}
+	let _: BitBox<AtomicU8, LocalBits> = bitbox![AtomicU8, LocalBits; 0, 1];
+	let _: BitBox<AtomicU8, Lsb0> = bitbox![AtomicU8, Lsb0; 0, 1];
+	let _: BitBox<AtomicU8, Msb0> = bitbox![AtomicU8, Msb0; 0, 1];
+
+	let _: BitBox<AtomicU16, LocalBits> = bitbox![AtomicU16, LocalBits; 0, 1];
+	let _: BitBox<AtomicU16, Lsb0> = bitbox![AtomicU16, Lsb0; 0, 1];
+	let _: BitBox<AtomicU16, Msb0> = bitbox![AtomicU16, Msb0; 0, 1];
+
+	let _: BitBox<AtomicU32, LocalBits> = bitbox![AtomicU32, LocalBits; 0, 1];
+	let _: BitBox<AtomicU32, Lsb0> = bitbox![AtomicU32, Lsb0; 0, 1];
+	let _: BitBox<AtomicU32, Msb0> = bitbox![AtomicU32, Msb0; 0, 1];
+
+	let _: BitBox<AtomicUsize, LocalBits> =
+		bitbox![AtomicUsize, LocalBits; 0, 1];
+	let _: BitBox<AtomicUsize, Lsb0> = bitbox![AtomicUsize, Lsb0; 0, 1];
+	let _: BitBox<AtomicUsize, Msb0> = bitbox![AtomicUsize, Msb0; 0, 1];
+
 	#[cfg(target_pointer_width = "64")]
-	radium::if_atomic! {
-		if atomic(64) {
-			let _: BitBox<AtomicU64, LocalBits> =bitbox![AtomicU64, LocalBits; 0, 1];
-			let _: BitBox<AtomicU64, Lsb0> =bitbox![AtomicU64, Lsb0; 0, 1];
-			let _: BitBox<AtomicU64, Msb0> =bitbox![AtomicU64, Msb0; 0, 1];
-			let _: BitBox<RadiumU64, LocalBits> =bitbox![RadiumU64, LocalBits; 1; 100];
-			let _: BitBox<RadiumU64, Lsb0> =bitbox![RadiumU64, Lsb0; 1; 100];
-			let _: BitBox<RadiumU64, Msb0> =bitbox![RadiumU64, Msb0; 1; 100];
-		}
+	{
+		let _: BitBox<AtomicU64, LocalBits> =
+			bitbox![AtomicU64, LocalBits; 0, 1];
+		let _: BitBox<AtomicU64, Lsb0> = bitbox![AtomicU64, Lsb0; 0, 1];
+		let _: BitBox<AtomicU64, Msb0> = bitbox![AtomicU64, Msb0; 0, 1];
 	}
 }
 

--- a/bitvec/src/mem.rs
+++ b/bitvec/src/mem.rs
@@ -6,8 +6,14 @@ use core::{
 };
 
 use funty::Unsigned;
-use radium::marker::BitOps;
 
+/// Marker trait for types supporting bit operations
+pub trait BitOps {}
+impl BitOps for u8 {}
+impl BitOps for u16 {}
+impl BitOps for u32 {}
+impl BitOps for u64 {}
+impl BitOps for usize {}
 #[doc = include_str!("../doc/mem/BitRegister.md")]
 pub trait BitRegister: Unsigned + BitOps {
 	/// The number of bits required to store an index in the range `0 .. BITS`.
@@ -101,8 +107,7 @@ macro_rules! element {
 			}
 		}
 
-		radium::if_atomic!( if atomic($size) {
-			use core::sync::atomic::$atom;
+			use atomic_polyfill::$atom;
 			impl BitElement<$atom> {
 				/// Creates a new element wrapper from a raw integer.
 				pub const fn new(elem: $bare) -> Self {
@@ -111,7 +116,6 @@ macro_rules! element {
 					}
 				}
 			}
-		});
 	)+ };
 }
 

--- a/bitvec/src/serdes.rs
+++ b/bitvec/src/serdes.rs
@@ -78,12 +78,9 @@ mod tests {
 
 	#[test]
 	fn trait_impls() {
-		use core::{
-			cell::Cell,
-			sync::atomic::*,
-		};
+		use core::cell::Cell;
 
-		use radium::types::*;
+		use atomic_polyfill::*;
 		macro_rules! check_impl {
 			($($ord:ident @ $($sto:ty),+);+ $(;)?) => {{ $( $(
 				assert_impl_all!(BitSlice<$sto, $ord>: Serialize);
@@ -108,53 +105,15 @@ mod tests {
 			Lsb0 @ Cell<u8>, Cell<u16>, Cell<u32>, Cell<usize>;
 			Msb0 @ Cell<u8>, Cell<u16>, Cell<u32>, Cell<usize>;
 			LocalBits @ Cell<u8>, Cell<u16>, Cell<u32>, Cell<usize>;
-			Lsb0 @ RadiumU8, RadiumU16, RadiumU32, RadiumUsize;
-			Msb0 @ RadiumU8, RadiumU16, RadiumU32, RadiumUsize;
-			LocalBits @ RadiumU8, RadiumU16, RadiumU32, RadiumUsize;
-		}
-		radium::if_atomic! {
-			if atomic(8) {
-				check_impl! {
-					Lsb0 @ AtomicU8;
-					Msb0 @ AtomicU8;
-					LocalBits @ AtomicU8;
-				}
-			}
-			if atomic(16) {
-				check_impl! {
-					Lsb0 @ AtomicU16;
-					Msb0 @ AtomicU16;
-					LocalBits @ AtomicU16;
-				}
-			}
-			if atomic(32) {
-				check_impl! {
-					Lsb0 @ AtomicU32;
-					Msb0 @ AtomicU32;
-					LocalBits @ AtomicU32;
-				}
-			}
-			if atomic(ptr) {
-				check_impl! {
-					Lsb0 @ AtomicUsize;
-					Msb0 @ AtomicUsize;
-					LocalBits @ AtomicUsize;
-				}
-			}
+			Lsb0 @ AtomicU8, AtomicU16, AtomicU32, AtomicUsize;
+			Msb0 @ AtomicU8, AtomicU16, AtomicU32, AtomicUsize;
+			LocalBits @ AtomicU8, AtomicU16, AtomicU32, AtomicUsize;
 		}
 		#[cfg(target_pointer_width = "64")]
 		check_impl! {
-			Lsb0 @ u64, RadiumU64;
-			Msb0 @ u64, RadiumU64;
-			LocalBits @ u64, RadiumU64;
+			Lsb0 @ AtomicU64;
+			Msb0 @ AtomicU64;
+			LocalBits @ AtomicU64;
 		}
-		#[cfg(target_pointer_width = "64")]
-		radium::if_atomic!(if atomic(64) {
-			check_impl! {
-				Lsb0 @ AtomicU64;
-				Msb0 @ AtomicU64;
-				LocalBits @ AtomicU64;
-			}
-		});
 	}
 }

--- a/bitvec/src/slice.rs
+++ b/bitvec/src/slice.rs
@@ -23,6 +23,7 @@ use wyz::{
 #[cfg(feature = "alloc")]
 use crate::vec::BitVec;
 use crate::{
+	access::InternalAtomic,
 	domain::{
 		BitDomain,
 		Domain,
@@ -1652,7 +1653,7 @@ where
 /// Methods available only when `T` allows shared mutability.
 impl<T, O> BitSlice<T, O>
 where
-	T: BitStore + radium::Radium,
+	T: BitStore + InternalAtomic,
 	O: BitOrder,
 {
 	/// Writes a new value into a single bit, using alias-safe operations.

--- a/bitvec/src/store.rs
+++ b/bitvec/src/store.rs
@@ -199,8 +199,7 @@ store!(usize => BitSafeUsize);
 /// Generates `BitStore` implementations for atomic types.
 macro_rules! atomic {
 	($($size:tt, $base:ty => $atom:ident);+ $(;)?) => { $(
-		radium::if_atomic!(if atomic($size) {
-			use core::sync::atomic::$atom;
+			use atomic_polyfill::$atom;
 
 			impl BitStore for $atom {
 				type Mem = $base;
@@ -228,7 +227,6 @@ macro_rules! atomic {
 
 				const ALIAS_WIDTH: [(); 1] = [()];
 			}
-		});
 	)+ };
 }
 
@@ -265,11 +263,9 @@ mod tests {
 		cell.store_value(39);
 		assert_eq!(cell.load_value(), 39);
 
-		radium::if_atomic!(if atomic(size) {
-			let mut atom = AtomicUsize::new(0);
-			atom.store_value(57);
-			assert_eq!(atom.load_value(), 57);
-		});
+		let mut atom = AtomicUsize::new(0);
+		atom.store_value(57);
+		assert_eq!(atom.load_value(), 57);
 	}
 
 	/// Unaliased `BitSlice`s are universally threadsafe, because they satisfy


### PR DESCRIPTION
Radium is a nice library for possible atomics, but it is really not usable
in embedded no_std environments. Version 1.0 also significantly changes the
API, and isn't really what bitvec wants (which is atomics that work everywhere).
It instead has "native atomics" and "best-effort atomics".

The standard way to make atomics work everywhere is now to use atomic_polyfill,
which makes atomics available either using native atomics or through polyfills
that use critical sections, and is a drop in replacement for core's Atomic\*;

This works on essentially all supported rust environments, both no_std and not.

Radium 0.7 does not work on no_std esp32, for example.

This patch makes bitvec use atomic_polyfill rather than radium.

It requires bumping the minimum rust version slightly from 1.56 to 1.60.

I have not finished updating the docs, wanted to see what you think first.
