### PR TITLE
feat: introduce RadiumFamily GATs for polymorphic atomic strategies

### DIFF
--- a/radium/Cargo.toml
+++ b/radium/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 	"LICENSE.txt",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 [features]
 portable-atomic = [

--- a/radium/examples/schroedinger.rs
+++ b/radium/examples/schroedinger.rs
@@ -12,13 +12,12 @@ use std::{
 };
 
 use radium::{
-	types::{
+	Radium, family::{AtomFamily, MaybeAtomic, RadiumFamily, RadonFamily}, types::{
 		Atom,
 		Isotope,
 		RadiumU64,
 		Radon,
-	},
-	Radium,
+	}
 };
 
 fn do_work<R: Radium<Item = u64>>(this: &R, ident: u8) {

--- a/radium/src/family.rs
+++ b/radium/src/family.rs
@@ -1,0 +1,139 @@
+use core::{cell::Cell};
+
+use crate::{Atom, Isotope, Radium, Radon, marker::{Atomic, Nuclear}};
+
+pub trait RadiumFamily{
+    type Me<T> : Radium<Item = T>
+    where
+        T: Atomic + Nuclear + PartialEq,
+        Cell<T>: Radium<Item = T>;
+}
+
+pub struct AtomFamily;
+impl RadiumFamily for AtomFamily {
+    type Me<T> = Atom<T>
+        where
+            T: Atomic + Nuclear + PartialEq,
+            Cell<T>: Radium<Item = T>;
+}
+
+pub struct IsotopeFamily;
+impl RadiumFamily for IsotopeFamily {
+    type Me<T> = Isotope<T>
+        where
+            T: Atomic + Nuclear + PartialEq,
+            Cell<T>: Radium<Item = T>;
+}
+
+pub struct RadonFamily;
+impl RadiumFamily for RadonFamily {
+    type Me<T> = Radon<T>
+        where
+            T: Atomic + Nuclear + PartialEq,
+            Cell<T>: Radium<Item = T>;
+}
+
+///This is a shortcut to make the code look more like regular generics.
+pub type MaybeAtomic<F, T> = <F as RadiumFamily>::Me<T>;
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use static_assertions::*;
+    use core::{ptr, sync::atomic::Ordering};
+    
+
+    type MaybeAtomic<F, T> = <F as RadiumFamily>::Me<T>;
+
+    struct Share<F: RadiumFamily> {
+
+        #[cfg(target_has_atomic = "8")]
+        bool: MaybeAtomic<F, bool>,
+        #[cfg(target_has_atomic = "8")]
+        u8: MaybeAtomic<F, u8>,
+        #[cfg(target_has_atomic = "8")]
+        i8: MaybeAtomic<F, i8>,
+
+        #[cfg(target_has_atomic = "16")]
+        u16: MaybeAtomic<F, u16>,
+        #[cfg(target_has_atomic = "16")]
+        i16: MaybeAtomic<F, i16>,
+
+        #[cfg(target_has_atomic = "32")]
+        u32: MaybeAtomic<F, u32>,
+        #[cfg(target_has_atomic = "32")]
+        i32: MaybeAtomic<F, i32>,
+
+        #[cfg(target_has_atomic = "64")]
+        u64: MaybeAtomic<F, u64>,
+        #[cfg(target_has_atomic = "64")]
+        i64: MaybeAtomic<F, i64>,
+
+        // 指针和大小类型
+        #[cfg(target_has_atomic = "ptr")]
+        usize: MaybeAtomic<F, usize>,
+        #[cfg(target_has_atomic = "ptr")]
+        isize: MaybeAtomic<F, isize>,
+        #[cfg(target_has_atomic = "ptr")]
+        ptr: MaybeAtomic<F, *mut u8>,
+    }
+
+    impl<F: RadiumFamily> Share<F> {
+        fn new() -> Self {
+            Self {
+                bool: Radium::new(false),
+
+                #[cfg(target_has_atomic = "8")]
+                u8: Radium::new(0),
+                #[cfg(target_has_atomic = "8")]
+                i8: Radium::new(0),
+
+                #[cfg(target_has_atomic = "16")]
+                u16: Radium::new(0),
+                #[cfg(target_has_atomic = "16")]
+                i16: Radium::new(0),
+
+                #[cfg(target_has_atomic = "32")]
+                u32: Radium::new(0),
+                #[cfg(target_has_atomic = "32")]
+                i32: Radium::new(0),
+
+                #[cfg(target_has_atomic = "64")]
+                u64: Radium::new(0),
+                #[cfg(target_has_atomic = "64")]
+                i64: Radium::new(0),
+
+                #[cfg(target_has_atomic = "ptr")]
+                usize: Radium::new(0),
+                #[cfg(target_has_atomic = "ptr")]
+                isize: Radium::new(0),
+                #[cfg(target_has_atomic = "ptr")]
+                ptr: Radium::new(ptr::null_mut()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_concurrency_safety() {
+        assert_impl_all!(Share<AtomFamily>: Sync);
+        assert_not_impl_any!(Share<RadonFamily>: Sync);
+    }
+
+    #[test]
+    fn test_operation() {
+        let s = Share::<RadonFamily>::new();
+        
+        #[cfg(target_has_atomic = "8")]
+        {
+        s.bool.store(true, Ordering::Relaxed);
+        assert!(s.bool.load(Ordering::Relaxed));
+        }
+        
+        #[cfg(target_has_atomic = "32")]
+        {
+            s.u32.fetch_add(10, Ordering::Relaxed);
+            assert_eq!(s.u32.load(Ordering::Relaxed), 10);
+        }
+    }
+}

--- a/radium/src/lib.rs
+++ b/radium/src/lib.rs
@@ -24,6 +24,7 @@ Jpbmc6Y3Jpc3BFZGdlc308L3N0eWxlPjwvc3ZnPg==")]
 pub mod marker;
 pub mod portable;
 pub mod types;
+pub mod family;
 
 use core::{
 	cell::Cell,


### PR DESCRIPTION

#### **Context & Motivation**
I am currently developing an async library intended to run in both **multi-threaded (SMP)** and **single-threaded (embedded/no-std)** environments. 

During development, I encountered a significant ergonomic issue: when a struct needs several atomic-like fields, I have to add a separate generic parameter for each field to allow users to switch between `Atom<T>`, `Isotope<T>`, or `Radon<T>`. This leads to "generic parameter explosion" and makes the code very hard to maintain.

**The Problem:**
```rust
// Without families, I have to do this:
struct MyState<A, B, C> 
where A: Radium<Item=u32>, B: Radium<Item=bool>, C: Radium<Item=*mut usize> 
{
    count: A,
    flag: B,
    ptr: C,
}
```

**The Solution (this PR):**
By introducing the `RadiumFamily` trait using **Generic Associated Types (GATs)**, we can now abstract the entire implementation strategy with a single type parameter:

```rust
// With RadiumFamily:
struct MyState<F: RadiumFamily> {
    count: MaybeAtomic<F, u32>,
    flag: MaybeAtomic<F, bool>,
    ptr: MaybeAtomic<F, *mut usize>,
}
```

#### **Changes**
- Added `RadiumFamily` trait in `src/family.rs`.
- Implemented `AtomFamily`, `IsotopeFamily`, and `RadonFamily`.

#### **Note to Maintainers**
- **First-time contributor:** This is my first time contributing to this project (and one of my first in the Rust ecosystem). Please let me know if I missed any project-specific conventions.
- **Language Barrier:** English is not my native language, so the documentation comments might not be perfectly phrased. I would appreciate any suggestions for better wording.
- **MSRV:** This feature relies on GATs (stable since Rust 1.65). If maintaining a lower MSRV is required, we might need to put this behind a feature gate.

I'm looking forward to your feedback!
